### PR TITLE
Fix delegate decorator not removing function from map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "utils-decorators",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/delegate/delegate.spec.ts
+++ b/src/delegate/delegate.spec.ts
@@ -41,6 +41,40 @@ describe('delegate', () => {
     expect(counter).toEqual(1);
   });
 
+  it('should delegate method with same key invocation until delegator is resolved / rejected', async () => {
+    const timestampBeforeTest = Date.now();
+    let counter = 0;
+
+    class T {
+      @delegate()
+      async foo(): Promise<number> {
+        counter += 1;
+        await sleep(20);
+
+        return Date.now();
+      }
+    }
+
+    const t = new T();
+    t.foo();
+    t.foo();
+
+    const res0 = await Promise.all([t.foo(), t.foo()]);
+    expect(res0[0]).toEqual(res0[1]);
+    expect(res0[0]).toBeGreaterThan(timestampBeforeTest);
+    expect(counter).toEqual(1);
+
+    t.foo();
+    t.foo();
+
+    const res1 = await Promise.all([t.foo(), t.foo()]);
+    expect(res1).not.toEqual(res0);
+
+    expect(res1[0]).toEqual(res1[1]);
+    expect(res1[0]).toBeGreaterThan(res0[0]);
+    expect(counter).toEqual(2);
+  });
+
   it('should delegate method with same key invocation - default key serialization', async () => {
     let counter = 0;
 

--- a/src/delegate/delegate.ts
+++ b/src/delegate/delegate.ts
@@ -17,7 +17,7 @@ export function delegate<T = any>(keyResolver?: (...args: any[]) => string): Del
         const key = keyGenerator(...args);
 
         if (!delegatedKeysMap.has(key)) {
-          delegatedKeysMap.set(key, originalMethod.apply(this, args));
+          delegatedKeysMap.set(key, originalMethod.apply(this, args).finally(() => delegatedKeysMap.delete(key)));
         }
 
         return delegatedKeysMap.get(key);


### PR DESCRIPTION
Hey! First of all, really cool library 😄
It seems like the map in the delegate decorator is acting like a permanent cache for the method to delegate. So even after the promise is resolved, the first result is being returned when calling the  method  with delegation again afterwards. I think this is not the expected behaviour according to the docs:

`For a given input, if within the time period of the resolving of the promise of the first invocation the decorated method was invoked multiple times (with the same input) the response would be the promise that was generated by the first invocation.`

This pr should fix the issue. I added a test in the spec to verify it!

As a sidenote, I would recommend you running `npm version  x.x.x` instead of updating the value mannually. It changes the version both on the package and package-lock files. When I npm installed the library locally, package-lock.json was modified automatically because of this.