### PR TITLE
fix: Error doesn't catch correctly (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.0.4] - 2022-05-13
+
+### Fixed 
+- `timeout`: error doesn't catch correctly [142](https://github.com/vlio20/utils-decorators/pull/142) closes [#143](https://github.com/vlio20/utils-decorators/issues/143) - Kudos to [gongpeione](https://github.com/gongpeione) for reporting and adding fixing.
+
 ## [2.0.3] - 2022-04-13
 
 ### Fixed 
@@ -21,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Enchantments
 
-- Support better types [131](https://github.com/vlio20/utils-decorators/pull/131) - Kudos to [tripodsgames](https://github.com/tripodsgames) for reporting and adding
+- Support better types [131](https://github.com/vlio20/utils-decorators/pull/131) - Kudos to [tripodsgames](https://github.com/tripodsgames) for reporting and fixing.
 
 ## [1.10.4] - 2021-10-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "utils-decorators",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils-decorators",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "decorators for reducing repetitive code",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/timeout/timeout.spec.ts
+++ b/src/timeout/timeout.spec.ts
@@ -56,4 +56,44 @@ describe('timeout', () => {
     const t = new T();
     expect(await t.foo()).toEqual(1);
   });
+
+  it('should catch original exception after the method throw an error within provided ms', async () => {
+    const ms = 50;
+
+    class T {
+      @timeout(ms)
+      async foo() {
+        await Promise.reject(1);
+        await sleep(100);
+      }
+    }
+
+    const t = new T();
+
+    try {
+      await t.foo();
+    } catch (e) {
+      expect(e).toEqual(1);
+    }
+  });
+
+  it('should catch timeout exception if the method throw an error after provided ms', async () => {
+    const ms = 50;
+
+    class T {
+      @timeout(ms)
+      async foo() {
+        await sleep(100);
+        await Promise.reject(1);
+      }
+    }
+
+    const t = new T();
+
+    try {
+      await t.foo();
+    } catch (e) {
+      expect(e).toBeInstanceOf(TimeoutError);
+    }
+  });
 });

--- a/src/timeout/timeoutify.ts
+++ b/src/timeout/timeoutify.ts
@@ -6,7 +6,7 @@ export function timeoutify<D = any, A extends any[] = any[]>(originalMethod: Asy
     return new Promise((resolve, reject) => {
       originalMethod.apply(this, args).then((data: any) => {
         resolve(data);
-      });
+      }).catch(reject);
 
       setTimeout(() => {
         reject(new TimeoutError(ms));


### PR DESCRIPTION
* fix: Error doesn't catch correctly

* test: add unit test

* test: should catch timeout exception if the method throw an error after provided ms