### PR TITLE
fix unhandled rejection on set cache exception

### DIFF
--- a/src/memoize-async/memoize-async.spec.ts
+++ b/src/memoize-async/memoize-async.spec.ts
@@ -403,6 +403,44 @@ describe('memozie-async', () => {
     throw new Error('shouldn\'t get to here');
   });
 
+  it('should throw exception when async set method throws an exception', async () => {
+    const map = new Map<string, number>();
+
+    const cache: AsyncCache<number> = {
+      delete: async (p1: string) => {
+        map.delete(p1);
+      },
+      get: async (p1: string) => map.get(p1),
+      has: async (p1: string) => map.has(p1),
+      set: async (p1: string, p2: number) => new Promise((resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error('error'));
+        });
+      }),
+    };
+
+    class T {
+      @memoizeAsync<T, number>({
+        expirationTimeMs: 30,
+        cache,
+      })
+      foo(): Promise<number> {
+        return Promise.resolve(1);
+      }
+    }
+
+    const t = new T();
+    try {
+      await t.foo();
+    } catch (e) {
+      expect(e.message).toBe('error');
+
+      return;
+    }
+
+    throw new Error('shouldn\'t get to here');
+  });
+
   it('should throw exception when original method is broken', async () => {
     const map = new Map<string, number>();
 

--- a/src/memoize-async/memoize-asyncify.ts
+++ b/src/memoize-async/memoize-asyncify.ts
@@ -70,7 +70,7 @@ export function memoizeAsyncify<D = any, A extends any[] = any[]>(
       } else {
         try {
           const data = await originalMethod.apply(this, args);
-          resolvedConfig.cache.set(key, data);
+          await resolvedConfig.cache.set(key, data);
 
           if (resolvedConfig.expirationTimeMs !== undefined) {
             runner.exec(() => {


### PR DESCRIPTION
When using an async cache and the 'set' operation throws an error we get "unhandled rejection".

`
import { AsyncCache, memoizeAsync } from 'utils-decorators';

class DistributedCache<T = any> implements AsyncCache<T> {
  private cache = {};

  async set(key: string, value: T): Promise<void> {
    return new Promise((resolve, reject) => {
      setTimeout(() => {
        reject('set cache value failed.');
      }, 1000);
    });
  }

  async get(key: string): Promise<any> {
    return await this.cache[key];
  }

  async delete(key: string): Promise<void> {
    delete this.cache[key];
  }

  async has(key: string): Promise<boolean> {
    const val = await this.get(key);

    return (val ?? null) !== null;
  }
}

class Test {
  @memoizeAsync({
    cache: new DistributedCache(),
  })
  getRand(): Promise<number> {
    return new Promise((resolve) => {
      setTimeout(() => {
        resolve(Math.floor(Math.random() * 1000));
      }, 1000);
    });
  }
}

const test = new Test();

test
  .getRand()
  .then((res) => console.log(`result: ${res}`))
  .catch((err) => console.log(`error: ${err}`));
`

**console output before the fix**:

result: 549
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "set cache value failed.".] {
  code: 'ERR_UNHANDLED_REJECTION'
}

**console output after the fix**:

error: set cache value failed.