### PR TITLE
Fix `delegate` default serialization with many args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "utils-decorators",
-      "version": "2.0.7",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "tinyqueue": "^2.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "utils-decorators",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "tinyqueue": "^2.0.3"

--- a/src/delegate/delegate.spec.ts
+++ b/src/delegate/delegate.spec.ts
@@ -95,6 +95,30 @@ describe('delegate', () => {
     expect(counter).toEqual(2);
   });
 
+  it('should delegate method with same key invocation - default key serialization - many args', async () => {
+    let counter = 0;
+
+    class T {
+      @delegate()
+      async foo(...args: number[]): Promise<number> {
+        counter += 1;
+        await sleep(20);
+
+        return Promise.resolve(args.reduce((a, b) => a + b));
+      }
+    }
+
+    const t = new T();
+
+    const res = await Promise.all([
+      t.foo(1, 1, 1, 1),
+      t.foo(1, 1, 1, 2),
+      t.foo(1, 1, 1, 1),
+    ]);
+    expect(res).toEqual([4, 5, 4]);
+    expect(counter).toEqual(2);
+  });
+
   it('should delegate method with same key invocation - custom serialization', async () => {
     let counter = 0;
 

--- a/src/delegate/delegatify.ts
+++ b/src/delegate/delegatify.ts
@@ -5,7 +5,7 @@ export function delegatify<D = any, A extends any[] = any[]>(
   keyResolver?: (...args: A) => string,
 ): AsyncMethod<D, A> {
   const delegatedKeysMap = new Map<string, Promise<any>>();
-  const keyGenerator: (...args: any[]) => string = keyResolver ?? JSON.stringify;
+  const keyGenerator: (...args: any[]) => string = keyResolver ?? ((...args) => JSON.stringify(args));
 
   return function (...args: A): Promise<D> {
     const key = keyGenerator(...args);


### PR DESCRIPTION
Looks like a typo in default serialization which is `(...args) => JSON.stringify(...args)` instead of `(...args) => JSON.stringify(args)` as it doesn't work for example in case of the decorated method having more than 3 arguments or more than 2 arguments with the first one not being an object.
