### PR TITLE
Return the original response in @exec-time

### DIFF
--- a/index.html
+++ b/index.html
@@ -727,8 +727,9 @@
       <div class="ud-section-content">
         <div class="ud-subtitle">Description:</div>
         <p class="ud-description">
-          Measures the time that takes for the decorated method to response.
-          By default will log the result using <i>console.info()</i> but this can be changed by providing your own
+          Measures the time that takes for the decorated method to respond.
+          Also returns the original response.
+          By default, will log the result using <i>console.info()</i> but this can be changed by providing your own
           reporter
           function.
         </p>

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -1,5 +1,5 @@
 export function isPromise(obj: any): obj is Promise<any> {
-  return !!(obj && obj.then !== undefined);
+  return !!(obj && typeof obj.then === 'function');
 }
 
 export function sleep(n: number): Promise<void> {

--- a/src/exec-time/exec-time.spec.ts
+++ b/src/exec-time/exec-time.spec.ts
@@ -31,11 +31,12 @@ describe('exec-time', () => {
     }
 
     const t = new T();
-    t.foo('a');
+    const returned = t.foo('a');
 
     expect(reporter).toBeCalledTimes(1);
     const args: ExactTimeReportData = reporter.mock.calls[0][0];
     expect(args.args).toEqual(['a']);
+    expect(returned).toEqual('ab');
     expect(args.result).toEqual('ab');
     expect(args.execTime).toBeGreaterThanOrEqual(0);
     expect(args.execTime).toBeLessThan(10);
@@ -54,11 +55,12 @@ describe('exec-time', () => {
     }
 
     const t = new T();
-    await t.foo('a');
+    const returned = await t.foo('a');
 
     expect(reporter).toBeCalledTimes(1);
     const args: ExactTimeReportData = reporter.mock.calls[0][0];
     expect(args.args).toEqual(['a']);
+    expect(returned).toEqual('ab');
     expect(args.result).toEqual('ab');
     expect(args.execTime).toBeGreaterThanOrEqual(8);
     expect(args.execTime).toBeLessThan(20);
@@ -75,14 +77,15 @@ describe('exec-time', () => {
     }
 
     const t = new T();
-    await t.foo('a');
+    const returned = await t.foo('a');
     expect(logSpy).toBeCalledTimes(1);
     const clogSpyArgs = logSpy.mock.calls[0][0];
     expect(clogSpyArgs).toBeGreaterThanOrEqual(0);
+    expect(returned).toEqual('ab');
     logSpy.mockRestore();
   });
 
-  it('should make sure that the reporter is called when provided as sting', async () => {
+  it('should make sure that the reporter is called when provided as string', async () => {
     class T {
       goo = jest.fn();
 
@@ -95,11 +98,12 @@ describe('exec-time', () => {
     }
 
     const t = new T();
-    await t.foo('a');
+    const returned = await t.foo('a');
 
     expect(t.goo).toBeCalledTimes(1);
     const args: ExactTimeReportData = t.goo.mock.calls[0][0];
     expect(args.args).toEqual(['a']);
+    expect(returned).toEqual('ab');
     expect(args.result).toEqual('ab');
     expect(args.execTime).toBeGreaterThanOrEqual(8);
     expect(args.execTime).toBeLessThan(20);


### PR DESCRIPTION
This example implies that `@execTime` decorator doesn't change the method signature:
```ts
    @execTime()
    getData(): Promise<DataDto> {
      return this.dataProvider.getData();
    }
``` 
But it's not true. This PR is fixing this.

Addressing #171 